### PR TITLE
Passing threshold parameters did not work

### DIFF
--- a/spikecomparison/groundtruthcomparison.py
+++ b/spikecomparison/groundtruthcomparison.py
@@ -249,7 +249,7 @@ class GroundTruthComparison(BaseTwoSorterComparison):
             A dict that contains some threshold of columns of perf Dataframe.
             If sevral threhold they are combined.
         """
-        if len(thresholds['thresholds']) == 0:
+        if len(thresholds) == 0:
             thresholds = {'accuracy': 0.95}
         else:
             thresholds = thresholds['thresholds']

--- a/spikecomparison/groundtruthcomparison.py
+++ b/spikecomparison/groundtruthcomparison.py
@@ -249,8 +249,10 @@ class GroundTruthComparison(BaseTwoSorterComparison):
             A dict that contains some threshold of columns of perf Dataframe.
             If sevral threhold they are combined.
         """
-        if len(thresholds) == 0:
+        if len(thresholds['thresholds']) == 0:
             thresholds = {'accuracy': 0.95}
+        else:
+            thresholds = thresholds['thresholds']
 
         _above = ['accuracy', 'recall', 'precision']
         _below = ['false_discovery_rate', 'miss_rate']


### PR DESCRIPTION
Please check if this is the way it was intended. Problem was that the argument threshold is a dict itself.