### PR TITLE
Unify labeling

### DIFF
--- a/spikecomparison/basecomparison.py
+++ b/spikecomparison/basecomparison.py
@@ -17,7 +17,7 @@ class BaseComparison:
     """
 
     def __init__(self, sorting_list, name_list=None, delta_time=0.4, sampling_frequency=None,
-                 min_accuracy=0.5, n_jobs=-1, verbose=False):
+                 match_score=0.5, chance_score=0.1, n_jobs=-1, verbose=False):
 
         self.sorting_list = sorting_list
         if name_list is None:
@@ -44,7 +44,8 @@ class BaseComparison:
         self.sampling_frequency = sampling_frequency
         self.delta_time = delta_time
         self.delta_frames = int(self.delta_time / 1000 * self.sampling_frequency)
-        self.min_accuracy = min_accuracy
+        self.match_score = match_score
+        self.chance_score = chance_score
         self._n_jobs = n_jobs
         self._verbose = verbose
 
@@ -55,7 +56,8 @@ class BaseTwoSorterComparison(BaseComparison):
     """
 
     def __init__(self, sorting1, sorting2, sorting1_name=None, sorting2_name=None,
-                 delta_time=0.4, sampling_frequency=None, min_accuracy=0.5, n_jobs=1, verbose=False):
+                 delta_time=0.4, sampling_frequency=None, match_score=0.5,
+                 chance_score=0.1, n_jobs=1, verbose=False):
 
         sorting_list = [sorting1, sorting2]
         if sorting1_name is None:
@@ -65,8 +67,8 @@ class BaseTwoSorterComparison(BaseComparison):
         name_list = [sorting1_name, sorting2_name]
 
         BaseComparison.__init__(self, sorting_list, name_list=name_list, delta_time=delta_time,
-                                sampling_frequency=sampling_frequency, min_accuracy=min_accuracy,
-                                n_jobs=n_jobs, verbose=verbose)
+                                sampling_frequency=sampling_frequency, match_score=0.5,
+                                chance_score=0.1, verbose=verbose)
 
         self.unit1_ids = self.sorting1.get_unit_ids()
         self.unit2_ids = self.sorting2.get_unit_ids()

--- a/spikecomparison/comparisontools.py
+++ b/spikecomparison/comparisontools.py
@@ -290,18 +290,12 @@ def make_best_match(agreement_scores, min_accuracy):
     best_match_12 = pd.Series(index=unit1_ids, dtype='int64')
     for i1, u1 in enumerate(unit1_ids):
         ind_max = np.argmax(scores[i1, :])
-        if scores[i1, ind_max] >= min_accuracy:
-            best_match_12[u1] = unit2_ids[ind_max]
-        else:
-            best_match_12[u1] = -1
+        best_match_12[u1] = unit2_ids[ind_max]
 
     best_match_21 = pd.Series(index=unit2_ids, dtype='int64')
     for i2, u2 in enumerate(unit2_ids):
         ind_max = np.argmax(scores[:, i2])
-        if scores[ind_max, i2] >= min_accuracy:
-            best_match_21[u2] = unit1_ids[ind_max]
-        else:
-            best_match_21[u2] = -1
+        best_match_21[u2] = unit1_ids[ind_max]
 
     return best_match_12, best_match_21
 

--- a/spikecomparison/comparisontools.py
+++ b/spikecomparison/comparisontools.py
@@ -417,8 +417,10 @@ def do_score_labels(sorting1, sorting2, delta_frames, unit_map12, label_misclass
                 inds2 = np.concatenate((inds2, [inds[-1]]))
                 times_matched = times_concat_sorted[inds2]
                 # find and label closest spikes
-                ind_st1 = np.array([np.abs(sts1[u1] - tm).argmin() for tm in times_matched])
-                ind_st2 = np.array([np.abs(mapped_st - tm).argmin() for tm in times_matched])
+                ind_st1 = np.array([np.abs(sts1[u1].tolist() - tm).argmin() for tm in times_matched])
+                ind_st2 = np.array([np.abs(mapped_st.tolist() - tm).argmin() for tm in times_matched])
+                assert(len(np.unique(ind_st1)) == len(ind_st1))
+                assert(len(np.unique(ind_st2)) == len(ind_st2))
                 lab_st1[ind_st1] = 'TP'
                 lab_st2[ind_st2] = 'TP'
         else:

--- a/spikecomparison/groundtruthcomparison.py
+++ b/spikecomparison/groundtruthcomparison.py
@@ -32,7 +32,8 @@ class GroundTruthComparison(BaseTwoSorterComparison):
     def __init__(self, gt_sorting, tested_sorting, gt_name=None, tested_name=None,
                  delta_time=0.4, sampling_frequency=None, min_accuracy=0.5, exhaustive_gt=False,
                  bad_redundant_threshold=0.2,
-                 n_jobs=-1, match_mode='hungarian', compute_labels=False, verbose=False):
+                 n_jobs=-1, match_mode='hungarian', compute_labels=False,
+                 compute_misclassifications=False, verbose=False):
 
         if gt_name is None:
             gt_name = 'ground truth'
@@ -44,6 +45,7 @@ class GroundTruthComparison(BaseTwoSorterComparison):
                                          min_accuracy=min_accuracy, n_jobs=n_jobs,
                                          verbose=verbose)
         self.exhaustive_gt = exhaustive_gt
+        self._compute_misclassifications = compute_misclassifications
         self._bad_redundant_threshold = bad_redundant_threshold
 
         assert match_mode in ['hungarian', 'best']
@@ -138,7 +140,8 @@ class GroundTruthComparison(BaseTwoSorterComparison):
             print("Adding labels...")
 
         self._labels_st1, self._labels_st2 = do_score_labels(self.sorting1, self.sorting2,
-                                                             self.delta_frames, self.hungarian_match_12, True)
+                                                             self.delta_frames, self.hungarian_match_12,
+                                                             self._compute_misclassifications)
 
     def get_performance(self, method='by_unit', output='pandas'):
         """
@@ -405,7 +408,8 @@ num_bad: {num_bad}
 def compare_sorter_to_ground_truth(gt_sorting, tested_sorting, gt_name=None, tested_name=None,
                                    delta_time=0.4, sampling_frequency=None, min_accuracy=0.5, exhaustive_gt=True,
                                    match_mode='hungarian',
-                                   n_jobs=-1, bad_redundant_threshold=0.2, compute_labels=False, verbose=False):
+                                   n_jobs=-1, bad_redundant_threshold=0.2, compute_labels=False,
+                                   compute_misclassifications=False, verbose=False):
     '''
     Compares a sorter to a ground truth.
 
@@ -443,7 +447,9 @@ def compare_sorter_to_ground_truth(gt_sorting, tested_sorting, gt_name=None, tes
         Agreement threshold below which a unit is considered 'false positive' and above
         which is considered 'redundant' (default 0.2)
     compute_labels: bool
-        If True, labels are computed at instantiation (default True)
+        If True, labels are computed at instantiation (default False)
+    compute_misclassifications: bool
+        If True, misclassifications are computed at instantiation (default False)
     verbose: bool
         If True, output is verbose
     Returns
@@ -456,5 +462,6 @@ def compare_sorter_to_ground_truth(gt_sorting, tested_sorting, gt_name=None, tes
                                  tested_name=tested_name, delta_time=delta_time, sampling_frequency=sampling_frequency,
                                  min_accuracy=min_accuracy, exhaustive_gt=exhaustive_gt, n_jobs=n_jobs,
                                  match_mode=match_mode,
-                                 compute_labels=compute_labels, bad_redundant_threshold=bad_redundant_threshold,
+                                 compute_labels=compute_labels, compute_misclassifications=compute_misclassifications,
+                                 bad_redundant_threshold=bad_redundant_threshold,
                                  verbose=verbose)

--- a/spikecomparison/multisortingcomparison.py
+++ b/spikecomparison/multisortingcomparison.py
@@ -10,11 +10,12 @@ import networkx as nx
 
 class MultiSortingComparison(BaseComparison):
     def __init__(self, sorting_list, name_list=None, delta_time=0.4, sampling_frequency=None,
-                 min_accuracy=0.5, n_jobs=-1, verbose=False):
+                 match_score=0.5, chance_score=0.1, n_jobs=-1, verbose=False):
 
         BaseComparison.__init__(self, sorting_list, name_list=name_list,
                                 delta_time=delta_time, sampling_frequency=sampling_frequency,
-                                min_accuracy=min_accuracy, n_jobs=n_jobs, verbose=verbose)
+                                match_score=match_score, chance_score=chance_score,
+                                n_jobs=n_jobs, verbose=verbose)
         self._do_matching(verbose)
 
     def get_sorting_list(self):
@@ -40,7 +41,7 @@ class MultiSortingComparison(BaseComparison):
                                                   sorting2_name=self.name_list[j],
                                                   delta_time=self.delta_time,
                                                   sampling_frequency=self.sampling_frequency,
-                                                  min_accuracy=self.min_accuracy,
+                                                  match_score=self.match_score,
                                                   n_jobs=self._n_jobs,
                                                   verbose=False)
                 self.comparisons.append(comp)
@@ -252,7 +253,7 @@ class AgreementSortingExtractor(se.SortingExtractor):
         return np.array(self._msc._spiketrains[list(self._msc._new_units.keys()).index(unit_id)])
 
 
-def compare_multiple_sorters(sorting_list, name_list=None, delta_time=0.4, min_accuracy=0.5,
+def compare_multiple_sorters(sorting_list, name_list=None, delta_time=0.4, match_score=0.5, chance_score=0.1,
                              n_jobs=-1, sampling_frequency=None, verbose=False):
     '''
     Compares multiple spike sorter outputs.
@@ -270,8 +271,10 @@ def compare_multiple_sorters(sorting_list, name_list=None, delta_time=0.4, min_a
         List of spike sorter names. If not given, sorters are named as 'sorter0', 'sorter1', 'sorter2', etc.
     delta_time: float
         Number of ms to consider coincident spikes (default 0.4 ms)
-    min_accuracy: float
+    match_score: float
         Minimum agreement score to match units (default 0.5)
+    chance_score: float
+        Minimum agreement score to for a possible match (default 0.1)
     n_jobs: int
        Number of cores to use in parallel. Uses all availible if -1
     sampling_frequency: float
@@ -285,5 +288,5 @@ def compare_multiple_sorters(sorting_list, name_list=None, delta_time=0.4, min_a
         MultiSortingComparison object with the multiple sorter comparison
     '''
     return MultiSortingComparison(sorting_list=sorting_list, name_list=name_list, delta_time=delta_time,
-                                  min_accuracy=min_accuracy, n_jobs=n_jobs, sampling_frequency=sampling_frequency,
-                                  verbose=verbose)
+                                  match_score=match_score, chance_score=chance_score, n_jobs=n_jobs,
+                                  sampling_frequency=sampling_frequency, verbose=verbose)

--- a/spikecomparison/symmetricsortingcomparison.py
+++ b/spikecomparison/symmetricsortingcomparison.py
@@ -11,20 +11,22 @@ class SymmetricSortingComparison(BaseTwoSorterComparison):
     """
 
     def __init__(self, sorting1, sorting2, sorting1_name=None, sorting2_name=None,
-                 delta_time=0.4, sampling_frequency=None, min_accuracy=0.5, n_jobs=-1, verbose=False):
+                 delta_time=0.4, sampling_frequency=None, match_score=0.5, chance_score=0.1,
+                 n_jobs=-1, verbose=False):
         BaseTwoSorterComparison.__init__(self, sorting1, sorting2, sorting1_name=sorting1_name,
                                          sorting2_name=sorting2_name,
                                          delta_time=delta_time, sampling_frequency=sampling_frequency,
-                                         min_accuracy=min_accuracy, n_jobs=n_jobs, verbose=verbose)
+                                         match_score=match_score, chance_score=chance_score,
+                                         n_jobs=n_jobs, verbose=verbose)
 
     def _do_matching(self):
         if self._verbose:
             print("Matching...")
 
-        self.possible_match_12, self.possible_match_21 = make_possible_match(self.agreement_scores, self.min_accuracy)
-        self.best_match_12, self.best_match_21 = make_best_match(self.agreement_scores, self.min_accuracy)
+        self.possible_match_12, self.possible_match_21 = make_possible_match(self.agreement_scores, self.chance_score)
+        self.best_match_12, self.best_match_21 = make_best_match(self.agreement_scores, self.chance_score)
         self.hungarian_match_12, self.hungarian_match_21 = make_hungarian_match(self.agreement_scores,
-                                                                                self.min_accuracy)
+                                                                                self.match_score)
 
     def get_mapped_sorting1(self):
         """
@@ -110,7 +112,7 @@ class MappedSortingExtractor(se.SortingExtractor):
 
 
 def compare_two_sorters(sorting1, sorting2, sorting1_name=None, sorting2_name=None, delta_time=0.4,
-                        sampling_frequency=None, min_accuracy=0.5, n_jobs=-1, verbose=False):
+                        sampling_frequency=None, match_score=0.5, chance_score=0.1, n_jobs=-1, verbose=False):
     '''
     Compares two spike sorter outputs.
 
@@ -135,8 +137,10 @@ def compare_two_sorters(sorting1, sorting2, sorting1_name=None, sorting2_name=No
         Number of ms to consider coincident spikes (default 0.4 ms)
     sampling_frequency: float
         Optional sampling frequency in Hz when not included in sorting        
-    min_accuracy: float
+    match_score: float
         Minimum agreement score to match units (default 0.5)
+    chance_score: float
+        Minimum agreement score to for a possible match (default 0.1)
     n_jobs: int
         Number of cores to use in parallel. Uses all available if -1
     verbose: bool
@@ -150,4 +154,5 @@ def compare_two_sorters(sorting1, sorting2, sorting1_name=None, sorting2_name=No
     return SymmetricSortingComparison(sorting1=sorting1, sorting2=sorting2, sorting1_name=sorting1_name,
                                       sorting2_name=sorting2_name, delta_time=delta_time,
                                       sampling_frequency=sampling_frequency,
-                                      min_accuracy=min_accuracy, n_jobs=n_jobs, verbose=verbose)
+                                      match_score=match_score, chance_score=chance_score,
+                                      n_jobs=n_jobs, verbose=verbose)

--- a/spikecomparison/test/test_groundtruthcomparison.py
+++ b/spikecomparison/test/test_groundtruthcomparison.py
@@ -63,17 +63,17 @@ def test_compare_sorter_to_ground_truth():
     # test well detected units depending on thresholds
     good_units = sc.get_well_detected_units()  # tp_thresh=0.95 default value
     assert_array_equal(good_units, [0, ])
-    good_units = sc.get_well_detected_units(accuracy=0.95)
+    good_units = sc.get_well_detected_units(well_detected_score=0.95)
     assert_array_equal(good_units, [0, ])
-    good_units = sc.get_well_detected_units(accuracy=.6)
-    assert_array_equal(good_units, [0, 1])
-    good_units = sc.get_well_detected_units(false_discovery_rate=0.05)
-    assert_array_equal(good_units, [0, 1])
-    good_units = sc.get_well_detected_units(accuracy=0.95, false_discovery_rate=.05)  # combine thresh
-    assert_array_equal(good_units, [0])
+    good_units = sc.get_well_detected_units(well_detected_score=.6)
+    assert_array_equal(good_units, [0, 5])
+    # good_units = sc.get_well_detected_units(false_discovery_rate=0.05)
+    # assert_array_equal(good_units, [0, 1])
+    # good_units = sc.get_well_detected_units(accuracy=0.95, false_discovery_rate=.05)  # combine thresh
+    # assert_array_equal(good_units, [0])
 
     # count
-    num_ok = sc.count_well_detected_units(accuracy=0.95)
+    num_ok = sc.count_well_detected_units(well_detected_score=0.95)
     assert num_ok == 1
 
     # false_positive_units [11]


### PR DESCRIPTION
- labeling TP spikes now uses the same logic as counting matches. For large delta_frames (several ms) there was a mismatch in the numbers