### PR TITLE
This fix the fact that now rec.load_probe_file(prb_filename) return a SubRecordingExtractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 - pip install https://github.com/SpikeInterface/spiketoolkit/archive/master.zip
 - pip install https://github.com/SpikeInterface/spikewidgets/archive/master.zip
 - pip install .
-- pip install PyQt5==1.14.0
+- pip install PyQt5==5.14.0
 - pip install tridesclous==1.4.2
 - pip install herdingspikes==0.3.2
 - pip install pytest==4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 - pip install https://github.com/SpikeInterface/spikewidgets/archive/master.zip
 - pip install .
 - pip install PyQt5==5.14.0
-- pip install tridesclous==1.4.2
+- pip install tridesclous==1.5.0
 - pip install herdingspikes==0.3.2
 - pip install pytest==4.3
 script: python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - pip install .
 - pip install PyQt5==5.14.0
 - pip install tridesclous==1.5.0
-- pip install herdingspikes==0.3.2
+- pip install herdingspikes==0.3.6
 - pip install pytest==4.3
 script: python -m pytest
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
 - pip install https://github.com/SpikeInterface/spiketoolkit/archive/master.zip
 - pip install https://github.com/SpikeInterface/spikewidgets/archive/master.zip
 - pip install .
-- pip install tridesclous==1.2.2
+- pip instal PyQt5==1.14.0
+- pip install tridesclous==1.4.2
 - pip install herdingspikes==0.3.2
 - pip install pytest==4.3
 script: python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 - pip install https://github.com/SpikeInterface/spiketoolkit/archive/master.zip
 - pip install https://github.com/SpikeInterface/spikewidgets/archive/master.zip
 - pip install .
-- pip instal PyQt5==1.14.0
+- pip install PyQt5==1.14.0
 - pip install tridesclous==1.4.2
 - pip install herdingspikes==0.3.2
 - pip install pytest==4.3

--- a/spikecomparison/groundtruthstudy.py
+++ b/spikecomparison/groundtruthstudy.py
@@ -184,7 +184,7 @@ class GroundTruthStudy:
 
         return snr
 
-    def get_units_snr(self, rec_name=None):
+    def get_units_snr(self, rec_name=None, **snr_kargs):
         """
         Load or compute units SNR for a given recording.
         """
@@ -199,7 +199,7 @@ class GroundTruthStudy:
             snr = pd.read_csv(filename, sep='\t', index_col=None)
             snr = snr.set_index('gt_unit_id')
         else:
-            snr = self._compute_snr(rec_name)
+            snr = self._compute_snr(rec_name, **snr_kargs)
             snr.reset_index().to_csv(filename, sep='\t', index=False)
         snr['rec_name'] = rec_name
         return snr

--- a/spikecomparison/groundtruthstudy.py
+++ b/spikecomparison/groundtruthstudy.py
@@ -199,5 +199,15 @@ class GroundTruthStudy:
         else:
             snr = self._compute_snr(rec_name)
             snr.reset_index().to_csv(filename, sep='\t', index=False)
-
+        snr['rec_name'] = rec_name
+        return snr
+    
+    def concat_all_snr(self):
+        snr = []
+        for rec_name in self.rec_names:
+            df = self.get_units_snr(rec_name)
+            df = df.reset_index()
+            snr.append(df)
+        snr = pd.concat(snr)
+        snr = snr.set_index(['rec_name', 'gt_unit_id'])
         return snr

--- a/spikecomparison/groundtruthstudy.py
+++ b/spikecomparison/groundtruthstudy.py
@@ -53,7 +53,7 @@ class GroundTruthStudy:
     def run_sorters(self, sorter_list, sorter_params={}, mode='keep',
                     engine='loop', engine_kargs={}, verbose=False):
         run_study_sorters(self.study_folder, sorter_list, sorter_params=sorter_params,
-                          engine=engine, engine_kargs=engine_kargs, verbose=verbose)
+                        mode=mode, engine=engine, engine_kargs=engine_kargs, verbose=verbose)
 
     def _check_rec_name(self, rec_name):
         if not self._is_scanned:

--- a/spikecomparison/groundtruthstudy.py
+++ b/spikecomparison/groundtruthstudy.py
@@ -139,9 +139,11 @@ class GroundTruthStudy:
             count_units.loc[(rec_name, sorter_name), 'num_sorter'] = len(sorting.get_unit_ids())
             count_units.loc[(rec_name, sorter_name), 'num_well_detected'] = \
                 comp.count_well_detected_units(well_detected_score)
-            count_units.loc[(rec_name, sorter_name), 'num_redundant'] = comp.count_redundant_units(redundant_score)
-            count_units.loc[(rec_name, sorter_name), 'num_overmerged'] = comp.count_overmerged_units(overmerged_score)
             if self.exhaustive_gt:
+                count_units.loc[(rec_name, sorter_name), 'num_overmerged'] = \
+                    comp.count_overmerged_units(overmerged_score)
+                count_units.loc[(rec_name, sorter_name), 'num_redundant'] = \
+                    comp.count_redundant_units(redundant_score)
                 count_units.loc[(rec_name, sorter_name), 'num_false_positive'] = \
                     comp.count_false_positive_units(redundant_score)
                 count_units.loc[(rec_name, sorter_name), 'num_bad'] = comp.count_bad_units()

--- a/spikecomparison/studytools.py
+++ b/spikecomparison/studytools.py
@@ -248,8 +248,8 @@ def copy_sortings_to_npz(study_folder):
         sorting = SorterClass.get_result_from_folder(output_folder)
         fname = rec_name + '[#]' + sorter_name
         se.NpzSortingExtractor.write_sorting(sorting, sorting_folders / (fname + '.npz'))
-        if os.path.exists(output_folder / 'run_log.txt'):
-            shutil.copyfile(output_folder / 'run_log.txt', sorting_folders / 'run_log' / (fname + '.txt'))
+        if os.path.exists(output_folder / 'spikeinterface_log.json'):
+            shutil.copyfile(output_folder / 'spikeinterface_log.json', sorting_folders / 'run_log' / (fname + '.json'))
 
 
 def iter_computed_names(study_folder):
@@ -288,10 +288,11 @@ def collect_run_times(study_folder):
 
     run_times = []
     for filename in os.listdir(log_folder):
-        if filename.endswith('.txt') and '[#]' in filename:
-            rec_name, sorter_name = filename.replace('.txt', '').split('[#]')
-            with open(log_folder / filename, mode='r') as logfile:
-                run_time = float(logfile.readline().replace('run_time:', ''))
+        if filename.endswith('.json') and '[#]' in filename:
+            rec_name, sorter_name = filename.replace('.json', '').split('[#]')
+            with open(log_folder / filename, encoding='utf8', mode='r') as logfile:
+                log = json.load(logfile)
+                run_time = log.get('run_time', None)
             run_times.append((rec_name, sorter_name, run_time))
 
     run_times = pd.DataFrame(run_times, columns=['rec_name', 'sorter_name', 'run_time'])

--- a/spikecomparison/test/test_groundtruthcomparison.py
+++ b/spikecomparison/test/test_groundtruthcomparison.py
@@ -16,7 +16,7 @@ def make_sorting(times1, labels1, times2, labels2):
 
 def test_compare_sorter_to_ground_truth():
     # simple match
-    gt_sorting, tested_sorting = make_sorting([100, 200, 300, 400, 500, 600], [0, 0, 1, 0, 1, 1],
+    gt_sorting, tested_sorting = make_sorting([100, 200, 300, 400, 500, 600, 700], [0, 0, 1, 0, 1, 1, 1],
                                               [101, 201, 301, 302, 401, 501, 502, 601, 900], [0, 0, 5, 6, 0, 5, 6, 5, 11])
 
     for match_mode in ('hungarian', 'best'):
@@ -26,7 +26,7 @@ def test_compare_sorter_to_ground_truth():
         sc = compare_sorter_to_ground_truth(gt_sorting, tested_sorting, exhaustive_gt=True,
                                             match_mode=match_mode, compute_labels=compute_labels)
 
-        assert_array_equal(sc.event_counts1.values, [3, 3])
+        assert_array_equal(sc.event_counts1.values, [3, 4])
         assert_array_equal(sc.event_counts2.values, [3, 3, 2, 1])
 
         assert_array_equal(sc.possible_match_12[1], [5, 6])
@@ -62,6 +62,7 @@ def test_compare_sorter_to_ground_truth():
 
     # test well detected units depending on thresholds
     good_units = sc.get_well_detected_units()  # tp_thresh=0.95 default value
+    print(good_units)
     assert_array_equal(good_units, [0, ])
     good_units = sc.get_well_detected_units(well_detected_score=0.95)
     assert_array_equal(good_units, [0, ])

--- a/spikecomparison/test/test_groundtruthcomparison.py
+++ b/spikecomparison/test/test_groundtruthcomparison.py
@@ -17,7 +17,7 @@ def make_sorting(times1, labels1, times2, labels2):
 def test_compare_sorter_to_ground_truth():
     # simple match
     gt_sorting, tested_sorting = make_sorting([100, 200, 300, 400, 500, 600], [0, 0, 1, 0, 1, 1],
-                                              [101, 201, 301, 302, 401, 501, 502, 900], [0, 0, 5, 6, 0, 5, 6, 11])
+                                              [101, 201, 301, 302, 401, 501, 502, 601, 900], [0, 0, 5, 6, 0, 5, 6, 5, 11])
 
     for match_mode in ('hungarian', 'best'):
 
@@ -27,7 +27,7 @@ def test_compare_sorter_to_ground_truth():
                                             match_mode=match_mode, compute_labels=compute_labels)
 
         assert_array_equal(sc.event_counts1.values, [3, 3])
-        assert_array_equal(sc.event_counts2.values, [3, 2, 2, 1])
+        assert_array_equal(sc.event_counts2.values, [3, 3, 2, 1])
 
         assert_array_equal(sc.possible_match_12[1], [5, 6])
 
@@ -41,7 +41,7 @@ def test_compare_sorter_to_ground_truth():
         assert_array_equal(scores.loc[ordered_scores.index, ordered_scores.columns], ordered_scores)
 
         assert sc.count_score.at[0, 'tp'] == 3
-        assert sc.count_score.at[1, 'tp'] == 2
+        assert sc.count_score.at[1, 'tp'] == 3
         assert sc.count_score.at[1, 'fn'] == 1
 
         sc._do_confusion_matrix()


### PR DESCRIPTION
This fix the fact that now rec.load_probe_file(prb_filename) return a SubRecordingExtractor.

It is a simplified load_probe_file version in the context of one group and all channel used.

Which is the case in ComparisonStudy


@colehurwitz @alejoe91 : it is a implss but faire fix of the problem I mention in spikeextractor.
